### PR TITLE
Switch to legacy VHX API endpoint

### DIFF
--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -170,7 +170,7 @@ function loadNextWord(video_urls) {
 }
 
 function fetchVideoInfo(video_url) {
-  $.get("http://api.vhx.tv/info.json", {url: video_url}, function (data) {
+  $.get("http://api.community.vhx.tv/info.json", {url: video_url}, function (data) {
     var video = data.video;
     megaplaya_call("growl", "<p>You're watching <span class='title'>" + video.title + "</span></p>");
 

--- a/spec/application_spec.js
+++ b/spec/application_spec.js
@@ -39,7 +39,7 @@ describe("Application", function () {
     });
 
     it("shows the video info from VHX", function() {
-      findAjax('http://api.vhx.tv/info.json', {url: 'http://youtube.com/watch?v=y-D_5Pnl0Nc'})
+      findAjax('http://api.community.vhx.tv/info.json', {url: 'http://youtube.com/watch?v=y-D_5Pnl0Nc'})
         .success({
           video: {
             description: "http://cyberhobo.com - what is a CyberHobo anyways?",


### PR DESCRIPTION
api.vhx.tv is our new API, so swap over to api.community.vhx.tv (which will remain in perpetuity)
